### PR TITLE
Add caching of user auth and LDAP groups

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,8 @@ TZ=America/Chicago
 RADIUS_REALM=acme.com
 RADIUS_SECRET=testing123
 
+TLS_CACHE_DIR=/var/log/freeradius/tlscache
+
 CERT_HOST=certs.acme.com
 
 MYSQL_HOST=${COMPOSE_PROJECT_NAME}_mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
         - RADIUS_SECRET=${RADIUS_SECRET}
         - CERT_HOST=${CERT_HOST}
         - TZ=${TZ}
+        - TLS_CACHE_DIR=${TLS_CACHE_DIR}
     secrets:
       - id_rsa
       - Google_sLDAP.crt

--- a/radius/Dockerfile
+++ b/radius/Dockerfile
@@ -17,6 +17,7 @@ ARG RADIUS_REALM
 ARG DB_IP
 ARG CERT_HOST
 ARG TZ
+ARG TLS_CACHE_DIR
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.vendor="DeepWoods Creations"
@@ -40,6 +41,7 @@ ENV DB_IP=${DB_IP:-192.168.5.6}
 ENV CERT_HOST=${CERT_HOST:-certs.acme.com}
 
 ENV TZ=${TZ:-America/Chicago}
+ENV TLS_CACHE_DIR=${TLS_CACHE_DIR:-/var/log/freeradius/tlscache}
 
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
@@ -105,8 +107,12 @@ COPY ./conf/cache /etc/freeradius/3.0/mods-available/cache
 #COPY ./conf/ldap /etc/freeradius/3.0/mods-available/ldap
 #COPY ./conf/set_group_vlan /etc/freeradius/3.0/policy.d/set_group_vlan
 COPY ./certs/ /etc/freeradius/3.0/certs/
+COPY ./conf/cache_auth /etc/freeradius/3.0/mods-available/cache_auth
 
 COPY init.sh /rad/
 COPY supervisor.conf /etc/
+
+# Create the persist_dir for the cache
+RUN mkdir "$TLS_CACHE_DIR" && chown freerad:freerad "$TLS_CACHE_DIR" && chmod 700 "$TLS_CACHE_DIR"
 
 CMD ["sh", "/rad/init.sh"]

--- a/radius/cache
+++ b/radius/cache
@@ -1,0 +1,10 @@
+cache {
+        key = "%{User-Name}"
+        ttl = 3600
+        add_stats = no
+        update {
+                &reply:Reply-Message += &reply:Reply-Message[*]
+                &reply:Reply-Message += "Cache last updated at %t"
+                &reply:Class := "%{randstr:ssssssssssssssssssssssssssssssss}"
+        }
+}

--- a/radius/cache_auth
+++ b/radius/cache_auth
@@ -1,0 +1,116 @@
+# -*- text -*-
+#
+#  $Id$
+
+#  This file contains a collection of cache module configurations
+#  which have been designed to be used to cache accepts, rejects, and
+#  LDAP User DNs.  The main use of these modules is Google Secure
+#  LDAP.
+#
+#  In scenarios where there is repeated authentication requests for the same
+#  user within a short time frame (e.g. 802.1x wifi), these modules can help to
+#  compensate for slow responses from poor LDAP servers (i.e. Google).
+#
+#  See also mods-available/ldap_google, and sites-available/google-ldap-auth.
+#
+#  The configurations in this file can be used for non-Google LDAP
+#  servers, too.
+#
+
+
+#
+#  This instance of the cache module caches successful
+#  authentications.
+#
+#  The TTL controls how often the authentication will be cached.  
+#
+#  In addition, if group membership is used as part of the policy, the
+#  &control:LDAP-Group attribute should be added to the "update: section here.
+#
+#  If a user's authentication is found in the cache, then any data
+#  which is normally retrieved from LDAP for local policies must also
+#  be stored in the cache via the "update" section.
+#
+cache cache_auth_accept {
+	driver = "rlm_cache_rbtree"
+	key = "%{md5:%{%{Stripped-User-Name}:-%{User-Name}}%{User-Password}}"
+	ttl = 7200
+	update {
+		#	
+		#  We need to cache something, so we just cache
+		#  a random attribute.  This attribute is not used
+		#  for anything else, just as a "place-holder" to
+		#  contain a cache entry.
+		#
+		#  If you add other attributes to this update section, then
+		#  this attribute can be deleted.
+		#
+		# &control:User-Category = "success"
+		&control:LDAP-Group = &control:LDAP-Group
+	}
+}
+
+
+#
+#  This instance of the cache module caches failed authentications.
+#
+#  In many cases, rejected users will repeatedly try to authenticate.
+#  These repeated authentication attempts can cause significant load
+#  on the system.  By caching the reject, we can avoid hitting the database.
+#
+#  We index the cache by a hash of the client's MAC and the user name
+#  and password.  If a user corrects their user name or password, then
+#  that authentication attempt won't hit the cache, and their
+#  credentials will be immediately checked against the database.
+#
+#  The TTL controls how long a combination of device / user and
+#  password wil be rejected without looking at the database.  Once the
+#  cache entry expires, the server will delete the cache entry, and
+#  contact the database.
+#
+cache cache_auth_reject {
+        driver = "rlm_cache_rbtree"
+        key = "%{md5:%{Calling-Station-Id}%{Stripped-User-Name}%{User-Password}}"
+        ttl = 3600
+        update {
+		#	
+		#  We need to cache something, so we just cache
+		#  a random attribute.  This attribute is not used
+		#  for anything else, just as a "place-holder" to
+		#  contain a cache entry.
+		#
+		&control:User-Category = "failure"
+        }
+}
+
+
+#
+#  An instance of the cache module which caches the LDAP user DN.
+#
+#  If LDAP authentication is being used for a simple auth / reject without
+#  any need to retrieve other attributes (e.g. group membership), each LDAP
+#  bind authentication is three steps
+#
+#    - bind as admin user
+#    - lookup user's DN
+#    - bind as user using retrieved DN
+#
+#  By caching the DN after the first LDAP querry, the first two steps
+#  are skipped on subsequent authentications.
+#
+#  If an alternative attribute name is being used for the user DN, you
+#  should change the update section here appropriately.  But that is
+#  likely rare.
+#
+#  In scenarios where DNs may change, consideration should be given as
+#  to whether use of this cache may create issues.  i.e. if the cache
+#  doesn't help, then don't use it.
+#
+cache cache_ldap_user_dn {
+	driver = "rlm_cache_rbtree"
+	key = "%{Stripped-User-Name}"
+	ttl = 86400
+	update {
+		&control:LDAP-UserDN = &control:LDAP-UserDN
+	}
+}

--- a/radius/conf/eap
+++ b/radius/conf/eap
@@ -29,8 +29,10 @@ eap {
                 tls_max_version = "1.2"
                 ecdh_curve = "prime256v1"
                 cache {
-                        enable = no
+                        enable = yes
                         lifetime = 24 # hours
+                        name = "EAP module"
+                        persist_dir = "${logdir}/tlscache"
                         store {
                                Tunnel-Private-Group-Id
                         }

--- a/radius/conf/inner-tunnel
+++ b/radius/conf/inner-tunnel
@@ -7,10 +7,65 @@ listen {
 authorize {
         filter_username
         suffix
+
+        #  Check the authentication cache to see if this user
+	#  recently sucessfully authenticated
         update control {
                 Cache-Status-Only = 'yes'
         }
+        cache_auth_accept
         cache
+
+        #  If there's a cached User-Name / User-Password which matches
+	#  what the user sent here, then the user has been
+	#  authenticated.  We can then avoid interacting with Google's
+	#  LDAP server, which significantly improves the performance
+	#  of user authentication.
+	#
+	if (ok) {
+		update {
+			&control:Auth-Type := Accept
+		}
+		cache_auth_accept
+		return
+	}
+
+	#
+	#  Check the reject cache to see if this user was
+	#  recently rejected
+	#
+	update control {
+		&Cache-Status-Only := 'yes'
+	}
+	cache_auth_reject
+
+	#
+	#  If there's a cached User-Name / User-Password which matches
+	#  what the user sent here, then the user has been rejected.
+	#  As with authentication above, we don't need to check
+	#  Google's LDAP server, and can improve performance.
+	#
+	#  Note that in may cases rejected users will try over and
+	#  over again.  This increased load can significantly affect
+	#  performance, and can even prevent other users from
+	#  authenticating!  The solution is to just tell the bad users
+	#  to "go away" as quickly as possible, while using minimal
+	#  resources.
+	#
+	if (ok) {
+		update {
+			&Module-Failure-Message := "Rejected by cache entry"
+		}
+		reject
+	}
+
+	#
+	#  If group membership checks are required, then ensure that
+	#  the relevant "cacheable_" option is set against the ldap
+	#  instance, and call the ldap module here.
+	#
+	#  If group membership is irrelevant, do not call ldap here
+	#  to improve performance
         eap {
                 ok = return
         }
@@ -69,12 +124,45 @@ post-auth {
                         &outer.session-state: += &reply:
                 }
         }
+        #  Cache the user's DN.  See the authorize section for
+	#  how and why this would be used
+	#
+	cache_ldap_user_dn
+
+	#
+	#  If a user was authenticated by ldap, add the users name /
+	#  password to the cache of successful authentications.
+	#
+	#  Otherwise the user was authenticated via the
+	#  cache_auth_accept call above, in the "authorize" section.
+	#
+	if (&control:Auth-Type == ldap) {
+		cache_auth_accept
+	}
+
         Post-Auth-Type REJECT {
                 sql
                 attr_filter.access_reject
                 update outer.session-state {
                         &Module-Failure-Message := &request:Module-Failure-Message
                 }
+                #  Record rejects in a cache, as a protection against
+		#  repeated attempts from mis-configured clients.
+		#
+		if (&control:Auth-Type == ldap) {
+			cache_auth_reject
+		}
+
+		#
+		#  Clear the DN cache entry if it exists.
+		#  If the DN cache is in use, retaining an incorrect
+		#  DN entry could cause issues if the user's DN
+		#  has changed.
+		#
+		update control {
+			&Cache-TTL := 0
+		}
+		cache_ldap_user_dn
         }
 }
 pre-proxy {

--- a/radius/conf/ldap
+++ b/radius/conf/ldap
@@ -12,6 +12,10 @@ ldap {
                 reply:                          += 'radiusReplyAttribute'
                 reply:Class := 'employeeType'
         }
+        #  If you change this, you will also need to update the
+	#  "cache_ldap_user_dn" module in mods-available/cache_auth.
+	#
+	user_dn = "LDAP-UserDn"
         user {
                 base_dn = "ou=Users,dc=acme,dc=com"           # <- GSuite LDAP base DN for user lookup
                 filter = "(uid=%{%{Stripped-User-Name}:-%{User-Name}})"
@@ -24,6 +28,10 @@ ldap {
                 name_attribute = cn
                 membership_attribute = 'memberOf'
                 membership_filter = "(|(member=%{control:Ldap-UserDn})(memberUid=%{%{Stripped-User-Name}:-%{User-Name}}))"
+                #  If the "memberOf" attribute is used for retrieving group membership,
+		#  then you should also use "cacheable_dn", in orser to cache the group details.
+		#  "memberOf" is a list of fully quallified group DNs which the user belongs to,
+		#  so using the DN for the cache avoids further lookups to retrieve group names.
                 cacheable_name = 'yes'
                 cacheable_dn = 'no'
         }

--- a/radius/init.sh
+++ b/radius/init.sh
@@ -54,6 +54,7 @@ ln -s /etc/freeradius/3.0/sites-available/status /etc/freeradius/3.0/sites-enabl
 # Enable modules for LDAP auth
 ln -s /etc/freeradius/3.0/mods-available/cache /etc/freeradius/3.0/mods-enabled/cache
 ln -s /etc/freeradius/3.0/mods-available/ldap /etc/freeradius/3.0/mods-enabled/ldap
+ln -s /etc/freeradius/3.0/mods-available/cache_auth /etc/freeradius/3.0/mods-enabled/cache_auth
 
 # add realm
 cat <<EOF >> /etc/freeradius/3.0/proxy.conf


### PR DESCRIPTION
Following the examples in the FreeRADIUS 3.2 branch for Google LDAP. Adds caching for user auth and LDAP groups.  This is working in testing to significantly reduce the need to connect to Google's LDAP servers.

(https://github.com/FreeRADIUS/freeradius-server/blob/v3.2.x/raddb/mods-available/ldap_google)

https://github.com/FreeRADIUS/freeradius-server/blob/v3.2.x/raddb/mods-available/cache_auth

https://github.com/FreeRADIUS/freeradius-server/blob/v3.2.x/raddb/sites-available/google-ldap-auth

I kept all the comments from the original files so it hopefully makes more sense.