### PR TITLE
Force TLS 1.2 and fix VLAN caching

### DIFF
--- a/radius/cache_auth
+++ b/radius/cache_auth
@@ -111,6 +111,8 @@ cache cache_ldap_user_dn {
 	key = "%{Stripped-User-Name}"
 	ttl = 86400
 	update {
-		&control:LDAP-UserDN = &control:LDAP-UserDN
+		# &control:LDAP-UserDN = &control:LDAP-UserDN
+		&control:LDAP-Group = &control:LDAP-Group
+        &control:Filter-Id = &control:Filter-Id
 	}
 }

--- a/radius/conf/eap
+++ b/radius/conf/eap
@@ -25,7 +25,7 @@ eap {
                 disable_tlsv1_2 = no
                 disable_tlsv1_1 = no
                 disable_tlsv1 = no
-                tls_min_version = "1.0"
+                tls_min_version = "1.2"
                 tls_max_version = "1.2"
                 ecdh_curve = "prime256v1"
                 cache {
@@ -35,6 +35,7 @@ eap {
                         persist_dir = "${logdir}/tlscache"
                         store {
                                Tunnel-Private-Group-Id
+                               Filter_Id
                         }
                 }
                 verify {

--- a/radius/conf/inner-tunnel
+++ b/radius/conf/inner-tunnel
@@ -14,7 +14,7 @@ authorize {
                 Cache-Status-Only = 'yes'
         }
         cache_auth_accept
-        cache
+        # cache
 
         #  If there's a cached User-Name / User-Password which matches
 	#  what the user sent here, then the user has been
@@ -27,6 +27,7 @@ authorize {
 			&control:Auth-Type := Accept
 		}
 		cache_auth_accept
+		cache_ldap_user_dn
 		return
 	}
 
@@ -80,7 +81,8 @@ authorize {
         update control {
                 Cache-Status-Only := 'no'
         }
-        cache
+        cache_ldap_user_dn
+		# cache
         expiration
         logintime
         pap


### PR DESCRIPTION
Fixed the issue with session resumption by adding the Filter_Id to the EAP cache.  Removed the unneeded cache calls from the inner-tunnel and added in cache_ldap_user_dn to make sure the group attributes are cached and recalled.  Changed cache_ldap_user_dn to cache only the LDAP-Group and the Filter-Id